### PR TITLE
- resolving pentaho-platform dependencies to '5.0.1-stable' (was TRUNK-S...

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ edit pentaho-solutions/system/security.properties and set security.provider=mult
 
 Note: at any time you can switch providers simply by declaring which one you intend to use on this security.properties file
 
-Accepted provider keys are: ldap, jdbc, memory, jackrabbit, multiple
+Accepted provider keys are: ldap, jdbc, memory, jackrabbit, multiple, super
 
 
 ### Launch the bi-server

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,5 @@
 project.revision=TRUNK-SNAPSHOT
+pentaho.project.revision=5.0.1-stable
 ivy.artifact.group=pentaho
 ivy.artifact.id=pentaho-platform-security-multipleuserrole
 impl.vendor=Webdetails

--- a/ivy.xml
+++ b/ivy.xml
@@ -29,9 +29,9 @@
         <dependency org="dom4j"               name="dom4j"               rev="1.6.1" transitive="false"/>
 		
         <!--  internal dependencies -->        
-        <dependency org="${ivy.artifact.group}" name="pentaho-platform-api"         rev="${project.revision}" changing="true" conf="default->default"/>    
-        <dependency org="${ivy.artifact.group}" name="pentaho-platform-core"        rev="${project.revision}" changing="true" conf="default->default"/>
-        <dependency org="${ivy.artifact.group}" name="pentaho-platform-extensions"  rev="${project.revision}" changing="true" conf="default->default"/>
+        <dependency org="${ivy.artifact.group}" name="pentaho-platform-api"         rev="${pentaho.project.revision}" changing="true" conf="default->default"/>    
+        <dependency org="${ivy.artifact.group}" name="pentaho-platform-core"        rev="${pentaho.project.revision}" changing="true" conf="default->default"/>
+        <dependency org="${ivy.artifact.group}" name="pentaho-platform-extensions"  rev="${pentaho.project.revision}" changing="true" conf="default->default"/>
     </dependencies>
     
 </ivy-module>

--- a/resources/applicationContext-spring-security-multiple.xml
+++ b/resources/applicationContext-spring-security-multiple.xml
@@ -58,7 +58,6 @@
   <bean id="providers" class="java.util.ArrayList">
      <constructor-arg>
       <util:list list-class="java.util.ArrayList" value-type="org.pentaho.platform.engine.security.multiple.auth.holder.Provider">
-        <ref bean="memory" />
         <ref bean="jackrabbit" />
       </util:list>
      </constructor-arg>
@@ -73,20 +72,6 @@
   <!-- /////////////// -->
   <!-- PROVIDERS INFO -->
   <!-- /////////////// -->
-
-  <!-- memoryUserDetailsService, inMemoryUserRoleListService, memoryPasswordEncoder are defined in application-context-*-security-memory.xml -->
-  <bean id="memory" class="org.pentaho.platform.engine.security.multiple.auth.holder.Provider">
-    <property name="id" value="memory" />
-    <property name="userDetailsService">
-      <ref bean="memoryUserDetailsService" />
-    </property>
-    <property name="userRoleListService">
-      <ref bean="inMemoryUserRoleListService" />
-    </property>
-    <property name="passwordEncoder">
-      <ref bean="memoryPasswordEncoder" />
-    </property>
-  </bean>
 
   <!-- userDetailsService, userRoleListService, jackrabbitPasswordEncoder are defined in application-context-*-security-jackrabbit.xml -->
   <bean id="jackrabbit" class="org.pentaho.platform.engine.security.multiple.auth.holder.Provider">


### PR DESCRIPTION
...NAPSHOT)
- updated multiple provider info list: now it starts off using a provider list of 1 element (read: base-install)
